### PR TITLE
Adding caffe module to the python path

### DIFF
--- a/caffe/Dockerfile.template
+++ b/caffe/Dockerfile.template
@@ -94,6 +94,9 @@ RUN cd /opt/caffe && \
 RUN cd /opt/caffe && \
   (pip install -r python/requirements.txt; easy_install numpy; pip install -r python/requirements.txt) && \
   easy_install pillow
+  
+# Add caffe module to the python path
+RUN bash -c 'echo "export PYTHONPATH=/opt/caffe/python:\$PYTHONPATH" >> ~/.bashrc'
 
 # Numpy include path hack - github.com/BVLC/caffe/wiki/Setting-up-Caffe-on-Ubuntu-14.04
 RUN NUMPY_EGG=`ls /usr/local/lib/python2.7/dist-packages | grep -i numpy` && \


### PR DESCRIPTION
This change will make the caffe module available for import from any directory.
