### PR TITLE
Dependency to use the tool draw_net.py

### DIFF
--- a/caffe/cpu/master/Dockerfile
+++ b/caffe/cpu/master/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && apt-get install -y \
   pkgconf \
   protobuf-compiler \ 
   python-dev \  
-  python-pip \ 
+  python-pip \
+  python-dot \
   unzip \
   wget 
 


### PR DESCRIPTION
`draw_net.py` is a tool to draw an image representation of a NN architecture.

This small change may be useful for the other Caffe's Dockerfiles.
