### PR TITLE
Ensure the CUDA libs and binaries are in the correct env variables

### DIFF
--- a/ubuntu-cuda/Dockerfile
+++ b/ubuntu-cuda/Dockerfile
@@ -20,14 +20,6 @@ RUN cd /opt && \
 RUN cd /opt/nvidia_installers && \
   ./cuda-linux64-rel-6.5.14-18749181.run -noprompt
 
-
-
-
-
-
-
-
-
-
-
-
+# Ensure the CUDA libs and binaries are in the correct environment variables
+ENV LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-6.5/lib64
+ENV PATH=$PATH:/usr/local/cuda-6.5/bin


### PR DESCRIPTION
In the `ubuntu-cuda` Dockerfile, the environment variables for `LD_LIBRARY_PATH` and `PATH` are not set, which means that once you start the container, you have no way of running `nvcc`, for example.

This pull request sets those variables as recommended by the CUDA Samples Installer, which states the following:

```
========================================

Configuring samples Makefile...

========================================

Please make sure that
 -   PATH includes /usr/local/cuda-6.5//bin
 -   LD_LIBRARY_PATH includes /usr/local/cuda-6.5//lib64, or, add /usr/local/cuda-6.5//lib64 to /etc/ld.so.conf and run ldconfig as root

To uninstall the NVIDIA CUDA Samples, run the uninstall script in /usr/local/cuda-6.5/samples
Installation Complete
```
